### PR TITLE
fix the exclude paths on codacy

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -11,23 +11,17 @@ tools:
       include_paths:
         - source/
         - specs/
-      exclude_paths:
-        - admin/
-        - .github/
-        - "**/*.md"
 
   stylelint:
     patterns:
       include_paths:
         - source/
         - specs/
-      exclude_paths:
-        - admin/
-        - .github/
-        - "**/*.md"
     
 exclude_paths:
   - admin/
+  - .github/
+  - "**/*.md"
 
 coverage:
   enabled: false


### PR DESCRIPTION
## Summary

Update Codacy configuration to exclude Markdown files from analysis and reduce unnecessary issue noise.

## Changes Made
- Updated .codacy.yaml to move **/*.md exclusion to the global exclude_paths
- Removed redundant exclude_paths from tool-specific ESLint and Stylelint blocks

## How to Test
1. Do a Codacy Reanalysis to remove all.md files from causing issues

## Related Issues
<!-- Link related issues using # -->
Closes #65 

## Screenshots (if applicable)
<!-- Include before/after UI screenshots or terminal output if relevant -->
## Checklist
- [ ] I have tested these changes locally
- [] I have added or updated relevant documentation
- [x] I have updated existing tests or added new tests
- [x] The code follows the project’s style guidelines
