### PR TITLE
Capitalization for Pokemon name

### DIFF
--- a/source/scripts/game.js
+++ b/source/scripts/game.js
@@ -121,7 +121,9 @@ function generateOptions(correctType) {
 
       const result = document.getElementById("result-msg");
       if (selectedAnswer === currentPokemon.type) {
-        result.textContent = `Correct! ${currentPokemon.name} added to your collection.`;
+        // Ensures that the name of the Pokemon is capitalized
+        const capitalizedName = currentPokemon.name.charAt(0).toUpperCase() + currentPokemon.name.slice(1);
+        result.textContent = `Correct! ${capitalizedName} added to your collection.`;
         result.style.color = "green";
 
         // Add persist to localStorage


### PR DESCRIPTION
## Summary
Minor change to make sure Pokemon name is capitalized when added

## Changes Made
Added a test-and-coverage job that:
    - Added capitalization function
   
## How to Test
<!-- Provide step-by-step instructions for testing -->
- Answer the type of a Pokemon correctly
- Observe message that pops up
## Related Issues

## Screenshots (if applicable)
<!-- Include before/after UI screenshots or terminal output if relevant -->
![image](https://github.com/user-attachments/assets/0e7b2c76-9dc7-4292-8b71-627f13d62b18)

## Checklist
- [x ] I have tested these changes locally
- [x] I have added or updated relevant documentation
- [] I have updated existing tests or added new tests
- [x] The code follows the project’s style guidelines
