### PR TITLE
Updated the Edit Page

### DIFF
--- a/source/edit_page.html
+++ b/source/edit_page.html
@@ -3,31 +3,41 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Pokémon Collection</title>
   <link rel="stylesheet" href="styles/style.css">
 </head>
-
 <body class="edit-mode">
   <div class="header"> <!-- Added header with Pokémon logo -->
     <img src="https://upload.wikimedia.org/wikipedia/commons/9/98/International_Pokémon_logo.svg"
          alt="Pokemon Logo" class="logo" />
-  </div class>
+  </div>
+  <h1>Edit My Pokémon Collection</h1>
 
-  <h1>Edit My Pokémon Card</h1>
-
-  <div id="card-container">
-    <!-- Individual will be inserted here (from collection)-->
-    <div class="pokemon-card"> <!-- Example Pokémon card (placeholder)-->
-      <img src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png" alt="Bulbasaur">
-      <h3>Bulbasaur</h3>
+  <div id="collection-container" class="collection-grid">
+    <!-- Collection cards will be inserted here (this is done in the collection.js file) -->
+    
+  </div>
+      <!-- Move Buttons -->
+    <div id="buttons">
+      <button id="prev-btn">⬅️ Previous</button>
+      <button id="next-btn">➡️ Next</button>
     </div>
   </div>
 
-  <div id="buttons">
-    <button id="delete-btn">❌ Delete Pokémon</button>
-    <button id="nickname-btn">✏️ Edit Nickname</button>
+  </div>
+      <!-- Edit/Delete Buttons -->
+    <div id="buttons">
+      <button id  = "nickname-btn">✏️ Edit</button>
+      <button id ="delete-btn">❌ Delete</button>
+    </div>
+  </div>
 
-  <script src="scripts/collection.js"></script>
+    <!-- Page Buttons -->
+  <div id="page-buttons">
+    <button onclick="location.href='collection.html'" class=".collection-btn-white">Go to Collection</button>
+    <button onclick="location.href='home_page.html'">Back to Home Page</button>
+  </div>
+
+  <script type="module" src="scripts/edit_page.js"></script>
 </body>
 </html>

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -17,10 +17,7 @@ function renderSingleCard() {
   if (currentIndex < 0) currentIndex = 0;
   if (currentIndex >= all.length) currentIndex = all.length - 1;
 
-  const index = Number(currentIndex);
-  if (!Number.isInteger(index) || index < 0 || index >= all.length) return;
-
-  const p = all[index];
+  const p = all[currentIndex];
 
   const card = document.createElement('div');
   card.className = 'pokemon-card';
@@ -39,18 +36,11 @@ function renderSingleCard() {
 function deleteCurrentCard() {
   if (collection.count === 0) return;
 
-  if (currentIndex < 0) currentIndex = 0;
-  if (currentIndex >= collection.count) currentIndex = collection.count - 1;
-
-  const index = Number(currentIndex);
-  if (!Number.isInteger(index) || index < 0 || index >= collection.count) return;
-
-  const deleted = collection.all[index];
-
+  const deleted = collection.all[currentIndex];
   if (!confirm(`Are you sure you want to delete ${deleted.name}?`)) return;
 
   // Remove the current Pokémon from the collection
-  collection._list.splice(index, 1);
+  collection._list.splice(currentIndex, 1);
   collection._save();
 
   // Adjust index if needed

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -1,0 +1,75 @@
+// scripts/edit_page.js
+import { collection } from './collection.js';
+
+let currentIndex = 0;
+
+function renderSingleCard() {
+  const container = document.getElementById('collection-container');
+  container.innerHTML = '';
+
+  const all = collection.all;
+
+  if (all.length === 0) {
+    container.innerHTML = '<p>No Pokémon in your collection.</p>';
+    return;
+  }
+
+  // Clamp index
+  if (currentIndex < 0) currentIndex = 0;
+  if (currentIndex >= all.length) currentIndex = all.length - 1;
+
+  const p = all[currentIndex];
+
+  const card = document.createElement('div');
+  card.className = 'pokemon-card';
+
+  const image = document.createElement('img');
+  image.src = p.img;
+  image.alt = p.name;
+
+  const heading = document.createElement('h3');
+  heading.textContent = p.nickname || p.name;
+
+  card.append(image, heading);
+  container.appendChild(card);
+}
+
+function deleteCurrentCard() {
+  if (collection.count === 0) return;
+
+  const deleted = collection.all[currentIndex];
+  if (!confirm(`Are you sure you want to delete ${deleted.name}?`)) return;
+
+  // Remove the current Pokémon from the collection
+  collection._list.splice(currentIndex, 1);
+  collection._save();
+
+  // Adjust index if needed
+  if (currentIndex >= collection.count) {
+    currentIndex = collection.count - 1;
+  }
+
+  renderSingleCard();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  renderSingleCard();
+
+  document.getElementById('next-btn').addEventListener('click', () => {
+    if (currentIndex < collection.count - 1) {
+      currentIndex++;
+      renderSingleCard();
+    }
+  });
+
+  document.getElementById('prev-btn').addEventListener('click', () => {
+    if (currentIndex > 0) {
+      currentIndex--;
+      renderSingleCard();
+    }
+  });
+
+  document.getElementById('delete-btn').addEventListener('click', () => {
+    deleteCurrentCard();
+  });
+});

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -17,7 +17,10 @@ function renderSingleCard() {
   if (currentIndex < 0) currentIndex = 0;
   if (currentIndex >= all.length) currentIndex = all.length - 1;
 
-  const p = all[currentIndex];
+  const index = Number(currentIndex);
+  if (!Number.isInteger(index) || index < 0 || index >= all.length) return;
+
+  const p = all[index];
 
   const card = document.createElement('div');
   card.className = 'pokemon-card';
@@ -36,11 +39,18 @@ function renderSingleCard() {
 function deleteCurrentCard() {
   if (collection.count === 0) return;
 
-  const deleted = collection.all[currentIndex];
+  if (currentIndex < 0) currentIndex = 0;
+  if (currentIndex >= collection.count) currentIndex = collection.count - 1;
+
+  const index = Number(currentIndex);
+  if (!Number.isInteger(index) || index < 0 || index >= collection.count) return;
+
+  const deleted = collection.all[index];
+
   if (!confirm(`Are you sure you want to delete ${deleted.name}?`)) return;
 
   // Remove the current Pokémon from the collection
-  collection._list.splice(currentIndex, 1);
+  collection._list.splice(index, 1);
   collection._save();
 
   // Adjust index if needed

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -14,7 +14,6 @@ function renderSingleCard() {
     return;
   }
 
-  // Clamp index
   if (currentIndex < 0) currentIndex = 0;
   if (currentIndex >= all.length) currentIndex = all.length - 1;
 

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -208,6 +208,18 @@ button { /* General button styles for navigation through pages */
   background: linear-gradient(to bottom, #e0ffe0, #fff); /* soft green gradient */
 }
 
+/* Collection button for edit page */
+.collection-btn-white {
+  background-color: #fc0;
+  border: none;
+  color: #fff;
+  font-size: 16px;
+  padding: 10px 25px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
 /* Optional: adjust header or card colors */
 .edit-mode .header {
   background-color: #8c8; /* green header */


### PR DESCRIPTION
## Summary
This PR makes changes to the edit page so that the cards from your collection show up one at time, you can move to the next and previous card. There are edit and delete buttons but right now only the delete button is implemented and not the edit button.

## Changes Made
<!-- List the main changes made in this pull request -->
- added Pokemon collection to edit page (only one card shows at a time)
- added the previous and next buttons to the edit page
- added an edit button (not implemented yet) and a delete button (implemented)
- added buttons to go back to the collection page and home page

## Screenshots (if applicable)
![edit-page](https://github.com/user-attachments/assets/d30681f9-0e9d-4610-af12-0fb034621ada)
![delete-pokemon](https://github.com/user-attachments/assets/2b226670-886f-4e5b-90d6-cdf3fea65b4d)

## Checklist
- [x] I have tested these changes locally
- [ ] I have added or updated relevant documentation
- [ ] I have updated existing tests or added new tests
- [x] The code follows the project’s style guidelines
