### PR TITLE
start none card in collection

### DIFF
--- a/__tests__/collectPokemon.test.js
+++ b/__tests__/collectPokemon.test.js
@@ -13,14 +13,11 @@ beforeEach(() => {
 });
 
 describe('Pokémon Collection', () => {
-  test('seeds with 3 starters on first run', () => {
-    // initially we should have Bulbasaur, Charmander, Squirtle
-    expect(collection.count).toBe(3);
+  test('starts with an empty collection on first run', () => {
+    expect(collection.count).toBe(0);
 
     const stored = JSON.parse(localStorage.getItem('pokemonCollection'));
-    expect(stored).toHaveLength(3);
-    const names = stored.map(p => p.name);
-    expect(names).toEqual(expect.arrayContaining(['Bulbasaur','Charmander','Squirtle']));
+    expect(stored).toHaveLength(0);
   });
 
   test('correct catch adds a new Pokémon to localStorage and to the DOM', () => {
@@ -33,13 +30,13 @@ describe('Pokémon Collection', () => {
 
     // before adding
     expect(collection.has(25)).toBe(false);
-    expect(collection.count).toBe(3);
+    expect(collection.count).toBe(0);
 
     // simulate a correct catch
     const wasAdded = collection.add(newPokemon);
     expect(wasAdded).toBe(true);
     expect(collection.has(25)).toBe(true);
-    expect(collection.count).toBe(4);
+    expect(collection.count).toBe(1);
 
     // check localStorage
     const stored = JSON.parse(localStorage.getItem('pokemonCollection'));
@@ -48,32 +45,35 @@ describe('Pokémon Collection', () => {
     // render and verify DOM
     renderCollection();
     const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(4);
+    expect(cards).toHaveLength(1);
     expect(document.body.textContent).toMatch(/Pikachu/);
   });
 
   test('duplicate catch does not add again', () => {
     const starter = { id: 1, name: 'Bulbasaur', img: '', nickname: '' };
+
+    // Add once, add successfully
+    const firstAdd = collection.add(starter);
+    expect(firstAdd).toBe(true);
     expect(collection.has(1)).toBe(true);
+    expect(collection.count).toBe(1);
 
-    // Attempt to add the same ID again
-    const wasAdded = collection.add(starter);
-    expect(wasAdded).toBe(false);
-
-    // Count stays the same
-    expect(collection.count).toBe(3);
+    // Add again, fail to add
+    const secondAdd = collection.add(starter);
+    expect(secondAdd).toBe(false);
+    expect(collection.count).toBe(1);
 
     renderCollection();
     const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(3);
+    expect(cards).toHaveLength(1);
   });
 
   test('wrong answer does not change the collection', () => {
     // Simulate a wrong answer by not calling collection.add()
-    expect(collection.count).toBe(3);
+    expect(collection.count).toBe(0);
     renderCollection();
 
     const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(3);
+    expect(cards).toHaveLength(0);
   });
 });

--- a/__tests__/collection.test.js
+++ b/__tests__/collection.test.js
@@ -14,20 +14,13 @@ beforeEach(() => {
 });
 
 describe('collection rendering', () => {
-  test('renders seeded starters on first load', () => {
-    
-    expect(collection.count).toBe(3);
+
+  test('shows empty message if no Pokémon in collection', () => {
+    expect(collection.count).toBe(0);
     renderCollection();
-
-    const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(3);
-
-    const names = Array.from(cards).map(card =>
-      card.querySelector('h3').textContent
-    );
-    expect(names).toEqual(
-      expect.arrayContaining(['Bulbasaur', 'Charmander', 'Squirtle'])
-    );
+  
+    const container = document.getElementById('collection-container');
+    expect(container.textContent).toContain("You don't have any Pokémon yet");
   });
 
   test('renders every Pokémon currently in localStorage, using nicknames when set', () => {
@@ -46,12 +39,12 @@ describe('collection rendering', () => {
     });
 
     // Now there should be 5 total
-    expect(collection.count).toBe(5);
+    expect(collection.count).toBe(2);
 
     renderCollection();
 
     const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(5);
+    expect(cards).toHaveLength(2);
 
     const displayedNames = Array.from(cards).map(card =>
       card.querySelector('h3').textContent
@@ -62,7 +55,7 @@ describe('collection rendering', () => {
     );
   });
 
-  test('clear() resets collection back to the 3 starters', () => {
+  test('clear() resets collection back to empty deck', () => {
     // Add and then clear
     collection.add({
       id:       25,
@@ -70,13 +63,13 @@ describe('collection rendering', () => {
       img:      'pikachu.png',
       nickname: ''
     });
-    expect(collection.count).toBe(4);
+    expect(collection.count).toBe(1);
 
     collection.clear();
-    expect(collection.count).toBe(3);
+    expect(collection.count).toBe(0);
 
     renderCollection();
     const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(3);
+    expect(cards).toHaveLength(0);
   });
 });

--- a/__tests__/game.test.js
+++ b/__tests__/game.test.js
@@ -59,7 +59,7 @@ test('clicking the correct button shows “Correct!” and adds to collection', 
 
   // if you renderCollection, you should see a card
   renderCollection();
-  expect(document.querySelectorAll('.pokemon-card')).toHaveLength(4); 
+  expect(document.querySelectorAll('.pokemon-card')).toHaveLength(1); 
 });
 
 test('clicking an incorrect button shows “Oops” and does NOT add to collection', async () => {
@@ -75,5 +75,5 @@ test('clicking an incorrect button shows “Oops” and does NOT add to collecti
 
   // no new catch
   expect(collection.has(25)).toBe(false);
-  expect(collection.count).toBe(3);
+  expect(collection.count).toBe(0);
 });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "url": "https://github.com/cse110-sp25-group17/cse110-sp25-group17/issues"
   },
   "homepage": "https://github.com/cse110-sp25-group17/cse110-sp25-group17#readme",
+  "jest": {
+    "testEnvironment": "jsdom",
+    "transform": {}
+  },
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "eslint": "^9.26.0",

--- a/source/scripts/collection.js
+++ b/source/scripts/collection.js
@@ -6,26 +6,7 @@
 - Exports a renderCollection() function that wipes and redraws the <div id="collection-container"> based on whatever’s currently in your stored collection
 */
 
-const starterPokemons = [
-  {
-    id: 1,
-    name: "Bulbasaur",
-    img: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png",
-    nickname: "",
-  },
-  {
-    id: 4,
-    name: "Charmander",
-    img: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png",
-    nickname: "",
-  },
-  {
-    id: 7,
-    name: "Squirtle",
-    img: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/7.png",
-    nickname: "",
-  },
-];
+const starterPokemons = [];
 
 export class Collection {
   constructor() {
@@ -78,6 +59,13 @@ export const collection = new Collection();
 export function renderCollection() {
   const container = document.getElementById("collection-container");
   if (!container) return;
+
+  if (collection.all.length === 0) {
+    container.innerHTML = `
+      <p>You don't have any Pokémon yet. <a href="game_page.html">Play the game</a> to catch some!</p>
+    `;
+    return;
+  }
 
   container.innerHTML = "";
   collection.all.forEach((p) => {


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of what this pull request does -->
## Changes Made
<!-- List the main changes made in this pull request -->
- Start none card when first entering the collection page instead of 3 initial cards
- link to the game page when no cards
-
## How to Test
<!-- Provide step-by-step instructions for testing -->
1. Already have tests, change the pass condition
2.
3.
## Related Issues
<!-- Link related issues using # -->
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/1d74c64f-955e-45f8-9192-d096ffa863ac" />

Closes #102 
## Screenshots (if applicable)
<!-- Include before/after UI screenshots or terminal output if relevant -->
## Checklist
- [x] I have tested these changes locally
- [x] I have added or updated relevant documentation
- [x] I have updated existing tests or added new tests
- [x] The code follows the project’s style guidelines
