### PR TITLE
add back 3 cards in collection when starting game

### DIFF
--- a/__tests__/collectPokemon.test.js
+++ b/__tests__/collectPokemon.test.js
@@ -13,12 +13,17 @@ beforeEach(() => {
 });
 
 describe('Pokémon Collection', () => {
-  test('starts with an empty collection on first run', () => {
-    expect(collection.count).toBe(0);
+  test('seeds with 3 starters on first run', () => {
+    // initially we should have Bulbasaur, Charmander, Squirtle
+    expect(collection.count).toBe(3);
 
     const stored = JSON.parse(localStorage.getItem('pokemonCollection'));
-    expect(stored).toHaveLength(0);
+    expect(stored).toHaveLength(3);
+    const names = stored.map(p => p.name);
+    expect(names).toEqual(expect.arrayContaining(['Bulbasaur','Charmander','Squirtle']));
+
   });
+
 
   test('correct catch adds a new Pokémon to localStorage and to the DOM', () => {
     const newPokemon = {
@@ -30,13 +35,13 @@ describe('Pokémon Collection', () => {
 
     // before adding
     expect(collection.has(25)).toBe(false);
-    expect(collection.count).toBe(0);
+    expect(collection.count).toBe(3);
 
     // simulate a correct catch
     const wasAdded = collection.add(newPokemon);
     expect(wasAdded).toBe(true);
     expect(collection.has(25)).toBe(true);
-    expect(collection.count).toBe(1);
+    expect(collection.count).toBe(4);
 
     // check localStorage
     const stored = JSON.parse(localStorage.getItem('pokemonCollection'));
@@ -45,35 +50,31 @@ describe('Pokémon Collection', () => {
     // render and verify DOM
     renderCollection();
     const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(1);
+    expect(cards).toHaveLength(4);
     expect(document.body.textContent).toMatch(/Pikachu/);
   });
 
   test('duplicate catch does not add again', () => {
     const starter = { id: 1, name: 'Bulbasaur', img: '', nickname: '' };
-
-    // Add once, add successfully
-    const firstAdd = collection.add(starter);
-    expect(firstAdd).toBe(true);
     expect(collection.has(1)).toBe(true);
-    expect(collection.count).toBe(1);
 
-    // Add again, fail to add
-    const secondAdd = collection.add(starter);
-    expect(secondAdd).toBe(false);
-    expect(collection.count).toBe(1);
+    // Attempt to add the same ID again
+    const wasAdded = collection.add(starter);
+    expect(wasAdded).toBe(false);
+    // Count stays the same
+    expect(collection.count).toBe(3);
 
     renderCollection();
     const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(1);
+    expect(cards).toHaveLength(3);
   });
 
   test('wrong answer does not change the collection', () => {
     // Simulate a wrong answer by not calling collection.add()
-    expect(collection.count).toBe(0);
+    expect(collection.count).toBe(3);
     renderCollection();
 
     const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(0);
+    expect(cards).toHaveLength(3);
   });
 });

--- a/__tests__/collection.test.js
+++ b/__tests__/collection.test.js
@@ -15,12 +15,20 @@ beforeEach(() => {
 
 describe('collection rendering', () => {
 
-  test('shows empty message if no Pokémon in collection', () => {
-    expect(collection.count).toBe(0);
+  test('renders seeded starters on first load', () => {
+
+    expect(collection.count).toBe(3);
     renderCollection();
-  
-    const container = document.getElementById('collection-container');
-    expect(container.textContent).toContain("You don't have any Pokémon yet");
+
+    const cards = document.querySelectorAll('.pokemon-card');
+    expect(cards).toHaveLength(3);
+
+    const names = Array.from(cards).map(card =>
+      card.querySelector('h3').textContent
+    );
+    expect(names).toEqual(
+      expect.arrayContaining(['Bulbasaur', 'Charmander', 'Squirtle'])
+    );
   });
 
   test('renders every Pokémon currently in localStorage, using nicknames when set', () => {
@@ -39,12 +47,12 @@ describe('collection rendering', () => {
     });
 
     // Now there should be 5 total
-    expect(collection.count).toBe(2);
+    expect(collection.count).toBe(5);
 
     renderCollection();
 
     const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(2);
+    expect(cards).toHaveLength(5);
 
     const displayedNames = Array.from(cards).map(card =>
       card.querySelector('h3').textContent
@@ -55,7 +63,7 @@ describe('collection rendering', () => {
     );
   });
 
-  test('clear() resets collection back to empty deck', () => {
+  test('clear() resets collection back to 3 cards', () => {
     // Add and then clear
     collection.add({
       id:       25,
@@ -63,13 +71,13 @@ describe('collection rendering', () => {
       img:      'pikachu.png',
       nickname: ''
     });
-    expect(collection.count).toBe(1);
+    expect(collection.count).toBe(4);
 
     collection.clear();
-    expect(collection.count).toBe(0);
+    expect(collection.count).toBe(3);
 
     renderCollection();
     const cards = document.querySelectorAll('.pokemon-card');
-    expect(cards).toHaveLength(0);
+    expect(cards).toHaveLength(3);
   });
 });

--- a/__tests__/game.test.js
+++ b/__tests__/game.test.js
@@ -59,7 +59,7 @@ test('clicking the correct button shows “Correct!” and adds to collection', 
 
   // if you renderCollection, you should see a card
   renderCollection();
-  expect(document.querySelectorAll('.pokemon-card')).toHaveLength(1); 
+  expect(document.querySelectorAll('.pokemon-card')).toHaveLength(4); 
 });
 
 test('clicking an incorrect button shows “Oops” and does NOT add to collection', async () => {
@@ -75,5 +75,5 @@ test('clicking an incorrect button shows “Oops” and does NOT add to collecti
 
   // no new catch
   expect(collection.has(25)).toBe(false);
-  expect(collection.count).toBe(0);
+  expect(collection.count).toBe(3);
 });

--- a/source/scripts/collection.js
+++ b/source/scripts/collection.js
@@ -6,7 +6,26 @@
 - Exports a renderCollection() function that wipes and redraws the <div id="collection-container"> based on whatever’s currently in your stored collection
 */
 
-const starterPokemons = [];
+const starterPokemons = [
+  {
+    id:       1,
+    name:     "Bulbasaur",
+    img:      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png",
+    nickname: ""
+  },
+  {
+    id:       4,
+    name:     "Charmander",
+    img:      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png",
+    nickname: ""
+  },
+  {
+    id:       7,
+    name:     "Squirtle",
+    img:      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/7.png",
+    nickname: ""
+  }
+];
 
 export class Collection {
   constructor() {
@@ -75,7 +94,7 @@ export function renderCollection() {
     `;
     return;
   }
-
+  
   container.innerHTML = "";
   collection.all.forEach(p => {
     // Create the links for each pokemon


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of what this pull request does -->
## Changes Made
<!-- List the main changes made in this pull request -->
-add back 3 cards in collection page when start the game 
-leave the link to game when the deck is empty (delete all cards by hands) 
-
## How to Test
<!-- Provide step-by-step instructions for testing -->
1. update all the pass condition in tests file
2.
3.
## Related Issues
<!-- Link related issues using # -->
Closes #
<img width="764" alt="image" src="https://github.com/user-attachments/assets/06110e12-3b60-48d9-82bc-9ff129c0f717" />
<img width="756" alt="image" src="https://github.com/user-attachments/assets/c9c7f0db-75d4-4feb-a818-1fb72b7ff585" />

## Screenshots (if applicable)
<!-- Include before/after UI screenshots or terminal output if relevant -->
## Checklist
- [x] I have tested these changes locally
- [x] I have added or updated relevant documentation
- [x] I have updated existing tests or added new tests
- [ ] The code follows the project’s style guidelines
