### PR TITLE
Changed collections page to display a max of 5 cards per row

### DIFF
--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -6,6 +6,8 @@ body {
   background: linear-gradient(to bottom, #e0f7ff, #fff);
   margin: 0;
   padding: 0;
+  overflow-x: hidden; /* Prevent horizontal scroll */
+  box-sizing: border-box;
 }
 
 /* Headings */
@@ -179,13 +181,6 @@ button {
 /* --------------------------------------------------
    Collection Grid & Cards
 -------------------------------------------------- */
-.collection-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 20px;
-  padding: 30px;
-  justify-items: center;
-}
 
 .collection-button-group {
   display: flex;
@@ -289,19 +284,17 @@ button {
    Displays a Max of 5 Cards Per Row
    Responsive Units
 -------------------------------------------------- */
-body {
-  overflow-x: hidden; /* Prevent horizontal scroll */
-  box-sizing: border-box;
-}
 
 .collection-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); /* responsive */
-  max-width: 1100px; /* constrain to 5 cards max */
-  margin: 0 auto;
-  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 20px;
   padding: 30px 16px;
+  margin: 0 auto;
+  max-width: 1100px;
+  width: 100%;
   justify-content: center;
+  justify-items: center;
   box-sizing: border-box;
 }
 

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -284,3 +284,30 @@ button {
   font-size: 24px;
   margin-top: 10px;
 }
+
+/* --------------------------------------------------
+   Displays a Max of 5 Cards Per Row
+   Responsive Units
+-------------------------------------------------- */
+body {
+  overflow-x: hidden; /* Prevent horizontal scroll */
+  box-sizing: border-box;
+}
+
+.collection-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); /* responsive */
+  max-width: 1100px; /* constrain to 5 cards max */
+  margin: 0 auto;
+  gap: 24px;
+  padding: 30px 16px;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.nickname {
+  font-size: 0.85rem;
+  color: black;
+  margin-top: 4px;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
This pull request improves the layout and appearance of the collection page by making the card grid responsive and styling nicknames for visual consistency. It ensures a maximum of 5 cards per row and prevents layout overflow or overlap across devices.
## Changes Made
- Applied responsive grid layout using auto-fit and minmax for .collection-grid
- Set a maximum width of 1100px to cap cards at 5 per row
- Added overflow-x: hidden to prevent horizontal scrolling
- Styled .nickname element to appear in italic, smaller font below each Pokémon name
## How to Test
<!-- Provide step-by-step instructions for testing -->
1.Run the app and navigate to the collection page
2. Resize the browser window and confirm that cards scale appropriately (1–5 cards per row)
3. Add Pokémon with and without nicknames and verify nickname styling
4. Ensure no horizontal scrolling occurs on desktop or mobile widths
## Related Issues
<!-- Link related issues using # -->
Closes #141
## Screenshots (if applicable)
<!-- Include before/after UI screenshots or terminal output if relevant -->
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/a44cb211-94e6-424f-a843-2146631c990a" />

## Checklist
- [x] I have tested these changes locally
- [x] I have added or updated relevant documentation
- [ ] I have updated existing tests or added new tests
- [x] The code follows the project’s style guidelines
HAVE NOT ADDED UNIT TESTS YET