### PR TITLE
Collections page law

### DIFF
--- a/source/scripts/collection.js
+++ b/source/scripts/collection.js
@@ -110,6 +110,7 @@ export function renderCollection() {
     image.src = p.img;
     image.alt = p.name;
 
+    // adds nickname to collection page card
     const heading = document.createElement("h3");
     heading.textContent = p.name;
 
@@ -122,4 +123,5 @@ export function renderCollection() {
     container.appendChild(link);
   });
 }
+
 

--- a/source/scripts/collection.js
+++ b/source/scripts/collection.js
@@ -111,10 +111,13 @@ export function renderCollection() {
     image.alt = p.name;
 
     const heading = document.createElement("h3");
-    heading.textContent = p.nickname || p.name;
-    
-    // Append the image and heading to the card, append that card to the link, and then append that to the container
-    card.append(image, heading);
+    heading.textContent = p.name;
+
+    const nickname = document.createElement("p");
+    nickname.textContent = p.nickname ? `(${p.nickname})` : "";
+    nickname.classList.add("nickname");
+
+    card.append(image, heading, nickname);
     link.appendChild(card);
     container.appendChild(link);
   });

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -199,6 +199,12 @@ button {
   padding: 20px;
   text-align: center;
   box-shadow: 0 6px 12px rgb(0 0 0 /10%);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pokemon-card:hover {
+  transform: scale(1.05);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.15);
 }
 
 .pokemon-card img {
@@ -287,20 +293,37 @@ button {
 
 .collection-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 20px;
-  padding: 30px 16px;
+  grid-template-columns: repeat(5, 1fr); /* Ensure min width fits your card */
+  gap: 10px;               /* More spacing between cards */
+  padding: 40px 20px;      /* More outer padding */
   margin: 0 auto;
-  max-width: 1100px;
+  max-width: 1200px;       /* Wider max width */
   width: 100%;
+  box-sizing: border-box;
   justify-content: center;
   justify-items: center;
-  box-sizing: border-box;
+}
+
+.collection-grid a {
+  color: black;
+  text-decoration: none;
+}
+
+@media (max-width: 1024px) {
+  .collection-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .collection-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .nickname {
   font-size: 0.85rem;
   color: black;
-  margin-top: 4px;
+  margin-top: 1px; /* Reduced from 4px to 2px */
   font-style: italic;
 }

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -190,6 +190,7 @@ button {
   flex-wrap: wrap;
 }
 
+/* Added select feature when hovering over card */
 .pokemon-card {
   width: 200px;
   height: 280px;
@@ -309,6 +310,7 @@ button {
   text-decoration: none;
 }
 
+/* Collection grid works on mobile devices */
 @media (max-width: 1024px) {
   .collection-grid {
     grid-template-columns: repeat(3, 1fr);
@@ -321,9 +323,11 @@ button {
   }
 }
 
+/* Nickname appears below actual pokemons name */
 .nickname {
   font-size: 0.85rem;
   color: black;
   margin-top: 1px; /* Reduced from 4px to 2px */
   font-style: italic;
 }
+


### PR DESCRIPTION
## Summary  
Improved the visual presentation and interactivity of the Pokémon collection cards on the collection page for a cleaner and more user-friendly interface.

## Changes Made  
- Pokémon names now display as plain black text instead of default blue links  
- Nicknames are shown below the Pokémon names in parentheses and are spaced closer to the name  
- Cards now slightly expand on hover with a smooth transition and enhanced box shadow  

## How to Test  
1. Navigate to the collection page  
2. Verify that the Pokémon names are black and not underlined  
3. Check that nicknames appear right below the name, in parentheses and italics  
4. Hover over any card and confirm that it expands slightly with a shadow effect  

## Related Issues  
Closes #

## Screenshots (if applicable)  
<!-- Include before/after UI screenshots or terminal output if relevant -->

## Checklist  
- [x] I have tested these changes locally  
- [X] I have added or updated relevant documentation  
- [ ] I have updated existing tests or added new tests  
- [x] The code follows the project’s style guidelines
