### PR TITLE
Nickname sanitization and hover disable

### DIFF
--- a/__tests__/sameName.test.js
+++ b/__tests__/sameName.test.js
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals';
+import { collection } from '../source/scripts/collection.js';
+import '../source/scripts/edit_page.js';
+
+beforeEach(() => {
+  // Clear storage and start fresh with Pikachu (id=25)
+  localStorage.clear();
+  collection.clear();
+  collection.add({
+    id:       25,
+    name:     'Pikachu',
+    img:      'pikachu.png',
+    nickname: ''
+  });
+
+  // simulate the Edit page HTML structure
+  document.body.innerHTML = `
+    <div class="header"></div>
+    <div id="card-container"></div>
+    <div id="buttons">
+      <button id="delete-btn">Delete</button>
+      <button id="nickname-btn">Nickname</button>
+      <button id="back-btn">Back</button>
+    </div>
+  `;
+
+  // test window.location so we can inspect href instead of real navigation
+  delete window.location;
+  window.location = {
+    href: '',
+    assign(url) { this.href = url; }
+  };
+});
+
+describe('Edit page behavior', () => {
+  // ... other tests above ...
+
+  test('nickname identical to original name is rejected', () => {
+    // Simulate visiting edit_page.html?id=25
+    Object.defineProperty(window, 'location', {
+      value: { search: '?id=25', href: '', assign(url) { this.href = url; } }
+    });
+
+    // Trigger DOMContentLoaded
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // Set nickname prompt to the same name (case-insensitive)
+    jest.spyOn(window, 'prompt').mockReturnValue('pikachu');
+    document.getElementById('nickname-btn').click();
+
+    // Should not redirect to collection.html
+    expect(window.location.href).not.toBe('collection.html');
+
+    // Nickname should remain unchanged
+    const stored = JSON.parse(localStorage.getItem('pokemonCollection'));
+    expect(stored.find(p => p.id === 25).nickname).toBe('');
+
+    window.prompt.mockRestore();
+  });
+});

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -59,10 +59,16 @@ document.addEventListener('DOMContentLoaded', () => {
   // Wire up Edit Nickname button
   nicknameBtn.addEventListener('click', () => {
     const newNick = prompt('Enter new nickname:');
-    if (!newNick || newNick.trim() === '') {
-      alert('No nickname entered; edit canceled.');
+    const trimmedNewNick = newNick.trim();
+
+    if (trimmedNewNick.toLowerCase() == pok.name.toLowerCase()) {
       return;
     }
+    
+    if (!newNick || trimmedNewNick === '') {
+      pok.nickname = pok.name;
+    }
+
     pok.nickname = newNick.trim();
     collection._save();
     window.location.assign('collection.html');

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -354,3 +354,9 @@ button {
   font-style: italic;
 }
 
+/* Disables hover on edit page */
+.edit-mode .pokemon-card:hover {
+  transform: none;
+  background-color: white; /* or whatever the default is */
+}
+


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of what this pull request does -->
This pull request enforces nickname validation to prevent users from setting a Pokémon's nickname to its original name and disables the hover animation effect on the edit page to reduce visual distraction and improve clarity.

## Changes Made
<!-- List the main changes made in this pull request -->
- Added validation logic in `edit_page.js` to prevent nicknames matching the Pokémon's official name (case-insensitive)
- Updated CSS in `style.css` to remove `.pokemon-card:hover` effects when in `.edit-mode`
- Added a Jest test to verify that nicknames cannot be set to the original name

## How to Test
<!-- Provide step-by-step instructions for testing -->
1. Go to the edit page of any Pokémon (e.g., `edit_page.html?id=25`)
2. Try entering the original name (e.g., "Pikachu") as the nickname → no changes should be made
3. Hover over the Pokémon card on the edit page → there should be no scale or background-color animation

## Related Issues
<!-- Link related issues using # -->
Closes #156 #157 <!-- (fill in the actual issue number if one exists) -->

## Screenshots (if applicable)
<!-- Include before/after UI screenshots or terminal output if relevant -->
<img width="1243" alt="image" src="https://github.com/user-attachments/assets/d0e746ab-95bd-4d85-b946-9eb67f35d556" />

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/fd980f9a-ce69-426e-90bf-12a4107135ce" />

<img width="244" alt="image" src="https://github.com/user-attachments/assets/84a47e22-af02-4404-81a6-95df35317cb0" />

## Checklist
- [x] I have tested these changes locally  
- [x] I have added or updated relevant documentation  
- [x] I have updated existing tests or added new tests  
- [x] The code follows the project’s style guidelines
