### PR TITLE
change border / background colors based on pokemon type (edit page)

### DIFF
--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Take the id from the URL
   const params = new URLSearchParams(window.location.search);
   const id = Number(params.get('id')); // e.g. 4 for Charmander
-
+  
   // Look it up in collection
   const pok = collection.all.find(p => p.id === id);
   const container = document.getElementById('card-container');
@@ -72,4 +72,41 @@ document.addEventListener('DOMContentLoaded', () => {
   backBtn.addEventListener('click', () => {
     window.location.assign('collection.html');
   });
+
+  // Change background color and border color of the card based on type
+  // API: https://pokeapi.co/api/v2/pokemon/{id}
+  // Example: https://pokeapi.co/api/v2/pokemon/4
+  const typeColors = {
+    fire: '#F08030',
+    water: '#6890F0',
+    grass: '#78C850',
+    electric: '#F8D030',
+    psychic: '#F85888',
+    ice: '#98D8D8',
+    dragon: '#7038F8',
+    dark: '#705848',
+    fairy: '#EE99AC',
+    normal: '#A8A878',
+    fighting: '#C03028',
+    flying: '#A890F0',
+    poison: '#A040A0',
+    ground: '#E0C068',
+    rock: '#B8A038',
+    bug: '#A8B820',
+  };
+  window.addEventListener('DOMContentLoaded', async () => {
+    const pokemonDataUrl = `https://pokeapi.co/api/v2/pokemon/` + id;
+    try {
+      const response = await fetch(pokemonDataUrl);
+      const pokemonData = await response.json();
+      const type = pokemonData.types[0].type.name;
+      card.style.borderColor = typeColors[type] ;
+      card.style.backgroundColor = `${typeColors[type]}60`;
+    }
+    catch (error) {
+      console.error('Error fetching Pokémon data:', error);
+    }
+  });
+  
 });
+


### PR DESCRIPTION
## Summary
Changed the colors of the card border / background to fit the pokemon's type.
## Changes Made
<!-- List the main changes made in this pull request -->
- Changed the colors of the card border / background to fit the pokemon's type (edit_page)
-
-
## How to Test
<!-- Provide step-by-step instructions for testing -->
1.  From home page, go to collection.
2. Select any pokemon in the selection to open the edit page.
3. The card's background and border should match the color of the pokemon's type (fire=red, water=blue, etc)
## Related Issues
<!-- Link related issues using # -->
Closes #
## Screenshots (if applicable)
![image (2)](https://github.com/user-attachments/assets/cf19d9c2-1ad1-4d52-a0f7-838338b19545)
![image (1)](https://github.com/user-attachments/assets/0539cfe6-093b-4c4c-bde6-9bfb4cda0c28)

## Checklist
- [x] I have tested these changes locally
- [x] I have added or updated relevant documentation
- [ ] I have updated existing tests or added new tests
- [x] The code follows the project’s style guidelines
