### PR TITLE
Change card border and background color

### DIFF
--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -111,8 +111,8 @@ document.addEventListener('DOMContentLoaded', () => {
         console.warn(`Type "${type}" not found in typeColors mapping.`);
         return;
       }
-      card.style.borderColor = typeColors[type];
-      card.style.backgroundColor = `${typeColors[type]}60`;
+      card.style.borderColor = typeColors[`${type}`];
+      card.style.backgroundColor = typeColors[`${type}60`];
     }
     catch (error) {
       console.error('Error fetching Pokémon data:', error);

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -78,7 +78,6 @@ document.addEventListener('DOMContentLoaded', () => {
   backBtn.addEventListener('click', () => {
     window.location.assign('collection.html');
   });
-
   // Change background color and border color of the card based on type
   // API: https://pokeapi.co/api/v2/pokemon/{id}
   // Example: https://pokeapi.co/api/v2/pokemon/4

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -105,10 +105,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const response = await fetch(pokemonDataUrl);
       const pokemonData = await response.json();
       const type = pokemonData.types[0].type.name;
-      if(typeColors[type]) {
-        card.style.borderColor = typeColors[type];
-        card.style.backgroundColor = `${typeColors[type]}60`;
-      } 
+      card.style.borderColor = typeColors[type] || '#A8A878'; // Default to normal type color
+      card.style.backgroundColor = `${typeColors[type]}60` || '#A8A87860'; // Default to normal type color with transparency
     }
     catch (error) {
       console.error('Error fetching Pokémon data:', error);

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -105,8 +105,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const response = await fetch(pokemonDataUrl);
       const pokemonData = await response.json();
       const type = pokemonData.types[0].type.name;
-      card.style.borderColor = typeColors[type] || '#A8A878'; // Default to normal type color
-      card.style.backgroundColor = `${typeColors[type]}60` || '#A8A87860'; // Default to normal type color with transparency
+      card.style.borderColor = typeColors[type];
+      card.style.backgroundColor = `${typeColors[type]}60`;
     }
     catch (error) {
       console.error('Error fetching Pokémon data:', error);

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -99,12 +99,18 @@ document.addEventListener('DOMContentLoaded', () => {
     rock: '#B8A038',
     bug: '#A8B820',
   };
+  const allowedTypes = Object.keys(typeColors);
   window.addEventListener('DOMContentLoaded', async () => {
     const pokemonDataUrl = `https://pokeapi.co/api/v2/pokemon/` + id;
     try {
       const response = await fetch(pokemonDataUrl);
       const pokemonData = await response.json();
       const type = pokemonData.types[0].type.name;
+
+      if (!allowedTypes.includes(type)) {
+        console.warn(`Type "${type}" not found in typeColors mapping.`);
+        return;
+      }
       card.style.borderColor = typeColors[type];
       card.style.backgroundColor = `${typeColors[type]}60`;
     }

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -105,8 +105,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const response = await fetch(pokemonDataUrl);
       const pokemonData = await response.json();
       const type = pokemonData.types[0].type.name;
-      card.style.borderColor = typeColors[type];
-      card.style.backgroundColor = `${typeColors[type]}60`;
+      if(typeColors[type]) {
+        card.style.borderColor = typeColors[type];
+        card.style.backgroundColor = `${typeColors[type]}60`;
+      } 
     }
     catch (error) {
       console.error('Error fetching Pokémon data:', error);

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -78,4 +78,39 @@ document.addEventListener('DOMContentLoaded', () => {
   backBtn.addEventListener('click', () => {
     window.location.assign('collection.html');
   });
+
+  // Change background color and border color of the card based on type
+  // API: https://pokeapi.co/api/v2/pokemon/{id}
+  // Example: https://pokeapi.co/api/v2/pokemon/4
+  const typeColors = {
+    fire: '#F08030',
+    water: '#6890F0',
+    grass: '#78C850',
+    electric: '#F8D030',
+    psychic: '#F85888',
+    ice: '#98D8D8',
+    dragon: '#7038F8',
+    dark: '#705848',
+    fairy: '#EE99AC',
+    normal: '#A8A878',
+    fighting: '#C03028',
+    flying: '#A890F0',
+    poison: '#A040A0',
+    ground: '#E0C068',
+    rock: '#B8A038',
+    bug: '#A8B820',
+  };
+  window.addEventListener('DOMContentLoaded', async () => {
+    const pokemonDataUrl = `https://pokeapi.co/api/v2/pokemon/` + id;
+    try {
+      const response = await fetch(pokemonDataUrl);
+      const pokemonData = await response.json();
+      const type = pokemonData.types[0].type.name;
+      card.style.borderColor = typeColors[type];
+      card.style.backgroundColor = `${typeColors[type]}60`;
+    }
+    catch (error) {
+      console.error('Error fetching Pokémon data:', error);
+    }
+  });
 });

--- a/source/scripts/edit_page.js
+++ b/source/scripts/edit_page.js
@@ -112,7 +112,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       card.style.borderColor = typeColors[`${type}`];
-      card.style.backgroundColor = typeColors[`${type}60`];
+      card.style.backgroundColor = typeColors[`${type}`] + '50';
     }
     catch (error) {
       console.error('Error fetching Pokémon data:', error);


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of what this pull request does -->
## Changed card's border / background color to fit pokemon type (edit_page)
<!-- List the main changes made in this pull request -->
- Changed card's border / background color to fit pokemon type (edit_page)
## How to Test
<!-- Provide step-by-step instructions for testing -->
1. Go to collections page
2. Select any pokemon card
3. Card's background and border color should match the pokemon type (fire = red, water = blue, etc)
## Related Issues
<!-- Link related issues using # -->
Closes #192 
## Screenshots (if applicable)
<!-- Include before/after UI screenshots or terminal output if relevant -->
<img width="764" alt="image" src="https://github.com/user-attachments/assets/757ba218-221a-4a2f-a381-d266e9a73dd4" />

## Checklist
- [x] I have tested these changes locally
- [x] I have added or updated relevant documentation
- [ ] I have updated existing tests or added new tests
- [x] The code follows the project’s style guidelines
