### PR TITLE
Add filter for fav pokemon

### DIFF
--- a/__tests__/dropdown.test.js
+++ b/__tests__/dropdown.test.js
@@ -38,6 +38,7 @@ describe('Type Filter Dropdown', () => {
     expect(options).toContain('grass');
     expect(options).toContain('fire');
     expect(options).toContain('water');
-    expect(options.length).toBe(4); // all + 3 types
+    expect(options).toContain('favorites');
+    expect(options.length).toBe(5); // all + 3 types
   });
 });

--- a/source/scripts/collection.js
+++ b/source/scripts/collection.js
@@ -112,7 +112,16 @@ function getAllTypes() {
 export function renderTypeFilter() {
   const select = document.getElementById("type-filter");
   if (!select) return;
+
+   // Clear everything except the "All Types" option
   select.querySelectorAll("option:not([value='all'])").forEach(opt => opt.remove());
+
+  // Add the favorites filter manually
+  const favOption = document.createElement("option");
+  favOption.value = "favorites";
+  favOption.textContent = "★ Favorites only";
+  select.appendChild(favOption);
+
   getAllTypes().forEach(type => {
     const opt = document.createElement("option");
     opt.value = type;
@@ -156,10 +165,12 @@ export function renderCollection() {
   const selectedType = select?.value || "all";
 
   let filtered = collection.all;
-  if (selectedType !== "all") {
+  if (selectedType === "favorites") {
+    const favs = getFavorites();
+    filtered = filtered.filter(p => favs.includes(p.id));
+  } else if (selectedType !== "all") {
     filtered = filtered.filter(p => p.type === selectedType);
   }
-
   if (filtered.length === 0) {
     container.innerHTML = `
       <p>You don't have any Pokémon of this type yet. <a href="game_page.html">Play the game</a> to catch some!</p>


### PR DESCRIPTION
## Summary
Added a filter for our Favorite Pokemons
## Changes Made
<!-- List the main changes made in this pull request -->
- Added the Favorite onto the dropdown FIlter
- Added the logic to render only the favorites when filtered
-
## How to Test
<!-- Provide step-by-step instructions for testing -->
1. favorite some pokemons then click the filter button
2.
3.
## Related Issues
Closes #185 

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/699ed3ad-a4e3-494a-b95d-4c7075268b58)

## Checklist
- [x] I have tested these changes locally
- [x] I have added or updated relevant documentation
- [x] I have updated existing tests or added new tests
- [x] The code follows the project’s style guidelines
