### PR TITLE
Add Nickname and Pokemon name under it

### DIFF
--- a/source/scripts/collection.js
+++ b/source/scripts/collection.js
@@ -205,12 +205,20 @@ export function renderCollection() {
     heading.textContent = p.nickname || p.name;
     card.append(heading);
 
-    // Nickname (if present and not already shown)
+    // // Nickname (if present and not already shown)
+    // if (p.nickname) {
+    //   const nicknameLine = document.createElement("p");
+    //   nicknameLine.textContent = `Nickname: ${p.nickname}`;
+    //   nicknameLine.classList.add("nickname");
+    //   card.append(nicknameLine);
+    // }
+    
+    // Always show real name if nickname exists
     if (p.nickname) {
-      const nickname = document.createElement("p");
-      nickname.textContent = `(${p.nickname})`;
-      nickname.classList.add("nickname");
-      card.append(nickname);
+      const officialLine = document.createElement("p");
+      officialLine.textContent = `${p.name}`;
+      officialLine.classList.add("official-name");
+      card.append(officialLine);
     }
 
     // Type info

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -396,12 +396,10 @@ button:disabled {
   }
 }
 
-/* Nickname appears below actual pokemons name */
-.nickname {
-  font-size: 0.85rem;
-  color: black;
-  margin-top: 1px; /* Reduced from 4px to 2px */
+.official-name {
   font-style: italic;
+  color: #666;
+  font-size: 0.9em;
 }
 
 /* Disables hover on edit page */


### PR DESCRIPTION
## Summary
Adds the Pokemon's actual name under the Nickname

## Changes Made
- Added the pokemon's actual name under the nickname
-
-
## How to Test
1. Go to Collections page and add a nickname
2.
3.
## Related Issues
Closes #188 
## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/7092bd02-92c7-410f-898d-7fb0c8f2a4c5)

## Checklist
- [x] I have tested these changes locally
- [x] I have added or updated relevant documentation
- [x] I have updated existing tests or added new tests
- [x] The code follows the project’s style guidelines
