### PR TITLE
Fix Nickname, No Favorites Error, and the Type of Pokemons

### DIFF
--- a/source/scripts/collection.js
+++ b/source/scripts/collection.js
@@ -172,9 +172,22 @@ export function renderCollection() {
     filtered = filtered.filter(p => p.type === selectedType);
   }
   if (filtered.length === 0) {
-    container.innerHTML = `
-      <p>You don't have any Pokémon of this type yet. <a href="game_page.html">Play the game</a> to catch some!</p>
-    `;
+    if (selectedType === "favorites") {
+      container.innerHTML = `
+        <div class="collection-message">
+          You haven’t favorited any Pokémon yet!<br>
+          Tap the <img src="../assets/images/icons/heart-white.png" alt="heart" class="inline-heart" />
+          icon to mark your favorites.
+        </div>
+      `;
+    } else {
+      container.innerHTML = `
+        <div class="collection-message">
+          You don't have any Pokémon of this type yet. 
+          <a href="game_page.html">Play the game</a> to catch some!
+        </div>
+      `;
+    }
     return;
   }
 
@@ -202,30 +215,50 @@ export function renderCollection() {
     card.append(image);
 
     const heading = document.createElement("h3");
-    heading.textContent = p.nickname || p.name;
+    heading.textContent = p.name;
     card.append(heading);
 
-    // // Nickname (if present and not already shown)
-    // if (p.nickname) {
-    //   const nicknameLine = document.createElement("p");
-    //   nicknameLine.textContent = `Nickname: ${p.nickname}`;
-    //   nicknameLine.classList.add("nickname");
-    //   card.append(nicknameLine);
-    // }
-    
-    // Always show real name if nickname exists
+    // Nickname (if present and not already shown)
     if (p.nickname) {
-      const officialLine = document.createElement("p");
-      officialLine.textContent = `${p.name}`;
-      officialLine.classList.add("official-name");
-      card.append(officialLine);
+      const nicknameLine = document.createElement("p");
+      nicknameLine.textContent = `${p.nickname}`;
+      nicknameLine.classList.add("nickname");
+      card.append(nicknameLine);
     }
 
-    // Type info
-    const typeInfo = document.createElement("p");
-    typeInfo.className = "pokemon-type";
-    typeInfo.textContent = `Type: ${capitalize(p.type || "Unknown")}`;
-    card.append(typeInfo);
+
+    const typeBadge = document.createElement("span");
+    typeBadge.className = "type-badge";
+    typeBadge.textContent = capitalize(p.type || "Unknown");
+
+    // Set color based on type map
+    const typeColorMap = new Map([
+      ["fire", "#ff6633"],
+      ["water", "#3399ff"],
+      ["grass", "#33cc33"],
+      ["electric", "#f9cc00"],
+      ["poison", "#aa00ff"],
+      ["normal", "#999999"],
+      ["flying", "#77ccff"],
+      ["bug", "#99cc33"],
+      ["steel", "#888888"],
+      ["psychic", "#ff3399"],
+      ["ground", "#cc9966"],
+      ["rock", "#aa9966"],
+      ["ice", "#66ccff"],
+      ["dragon", "#9966cc"],
+      ["ghost", "#6666cc"],
+      ["dark", "#444444"],
+      ["fairy", "#ffccff"],
+      ["fighting", "#cc3333"],
+    ]);
+
+    const typeColor = typeColorMap.get((p.type || "").toLowerCase());
+
+    if (typeColor) {
+      typeBadge.style.backgroundColor = typeColor;
+    }
+    card.append(typeBadge);
 
     // favorite icon
     const favIcon = document.createElement('span');

--- a/source/scripts/collection.js
+++ b/source/scripts/collection.js
@@ -205,12 +205,20 @@ export function renderCollection() {
     heading.textContent = p.nickname || p.name;
     card.append(heading);
 
-    // Nickname (if present and not already shown)
+    // // Nickname (if present and not already shown)
+    // if (p.nickname) {
+    //   const nicknameLine = document.createElement("p");
+    //   nicknameLine.textContent = `Nickname: ${p.nickname}`;
+    //   nicknameLine.classList.add("nickname");
+    //   card.append(nicknameLine);
+    // }
+    
+    // Always show real name if nickname exists
     if (p.nickname) {
-      const nickname = document.createElement("p");
-      nickname.textContent = `(${p.nickname})`;
-      nickname.classList.add("nickname");
-      card.append(nickname);
+      const officialLine = document.createElement("p");
+      officialLine.textContent = `${p.name}`;
+      officialLine.classList.add("official-name");
+      card.append(officialLine);
     }
 
     // Type info

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -396,12 +396,10 @@ button:disabled {
   }
 }
 
-/* Nickname appears below actual pokemons name */
-.nickname {
-  font-size: 0.85rem;
-  color: black;
-  margin-top: 1px; /* Reduced from 4px to 2px */
+.official-name {
   font-style: italic;
+  color: #666;
+  font-size: 0.9em;
 }
 
 /* Disables hover on edit page */

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -249,7 +249,7 @@ button:disabled {
 /* Added select feature when hovering over card */
 .pokemon-card {
   width: 200px;
-  height: 300px;
+  height: 290px;
   background: white;
   border: 3px solid #0074d9;
   border-radius: 14px;
@@ -274,7 +274,8 @@ button:disabled {
 }
 
 .pokemon-card h3 {
-  margin-top: 10px;
+  margin-top: 4px;
+  margin-bottom: 4px;
   font-size: 20px;
 }
 
@@ -396,10 +397,11 @@ button:disabled {
   }
 }
 
-.official-name {
+.nickname {
   font-style: italic;
   color: #666;
   font-size: 0.9em;
+   margin: 2px 0 4px;
 }
 
 /* Disables hover on edit page */
@@ -429,4 +431,41 @@ button:disabled {
   text-align: center;
   padding: 2rem;
   display: none; /* hidden by default */
+}
+
+.type-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.85em;
+  font-weight: bold;
+  margin: 4px 0;
+  line-height: 1.2;
+  text-transform: capitalize;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+.collection-message {
+  grid-column: 1 / -1; /* spans all columns in the grid */
+  text-align: center;
+  color: #cc0000; /* Pokémon red */
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-top: 40px;
+  font-family: 'Verdana', 'Segoe UI', sans-serif;
+  padding: 20px;
+  line-height: 1.6;
+}
+
+.collection-message a {
+  color: #0074d9;
+  text-decoration: underline;
+  font-weight: normal;
+}
+
+.inline-heart {
+  width: 35px;
+  height: 35px;
+  vertical-align: middle;
+  margin: 0;
 }

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -442,17 +442,16 @@ button:disabled {
   margin: 4px 0;
   line-height: 1.2;
   text-transform: capitalize;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 5px rgb(0 0 0 / 10%);
 }
 
 .collection-message {
   grid-column: 1 / -1; /* spans all columns in the grid */
   text-align: center;
-  color: #cc0000; /* Pokémon red */
+  color: #c00;
   font-size: 1.5rem;
   font-weight: bold;
   margin-top: 40px;
-  font-family: 'Verdana', 'Segoe UI', sans-serif;
   padding: 20px;
   line-height: 1.6;
 }
@@ -466,6 +465,6 @@ button:disabled {
 .inline-heart {
   width: 35px;
   height: 35px;
-  vertical-align: middle;
+  vertical-align: bottom;
   margin: 0;
 }


### PR DESCRIPTION
## Summary
Adds the Nickname below the pokemons actual nickname
Added the colors for the type to make it look cleaner
Also added the error message for filtering by favorites and we have no favorites

## Changes Made
- Make sure that the original pokemon's name is displayed
- added .nickname and .type-badge onto the styling
- Added type badge logic onto the Collection.js
## How to Test
1. Go to Collections page and add a nickname
2. Filter by Favorites and it should display an error message saying we have no favorite pokemon
3.
## Related Issues
Closes #188 
Closes #195 
Closes #194 
## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/ab8ca2eb-1c28-4fbe-824e-265add61cc41)


No favorites:
![image](https://github.com/user-attachments/assets/db6772b5-a221-4dc8-8c19-d1bc1df5a77e)

## Checklist
- [x] I have tested these changes locally
- [x] I have added or updated relevant documentation
- [x] I have updated existing tests or added new tests
- [x] The code follows the project’s style guidelines
